### PR TITLE
feat: redirect all routes to the homepage

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,12 @@
+import { redirect, type Handle } from '@sveltejs/kit';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const { pathname } = event.url;
+
+	// Only redirect if it's not the homepage and not a SvelteKit internal or static asset request
+	if (pathname !== '/' && !pathname.startsWith('/_app/') && !pathname.includes('.')) {
+		throw redirect(307, '/');
+	}
+
+	return await resolve(event);
+};


### PR DESCRIPTION
Implement a server-side handle hook in src/hooks.server.ts to redirect any request that is not the homepage ('/'), a SvelteKit internal path (starting with '/_app/'), or a static asset (containing a '.') to the homepage with a 307 status code. This ensures all non-essential routes are redirected while maintaining site functionality.

---
*PR created automatically by Jules for task [12551676242414928170](https://jules.google.com/task/12551676242414928170) started by @lordbagel42*